### PR TITLE
Catch lambda task execution failures and report correctly

### DIFF
--- a/task-satisfier/spec/executors/lambda/index.spec.js
+++ b/task-satisfier/spec/executors/lambda/index.spec.js
@@ -1,12 +1,16 @@
 const lambdaExecutor = require('../../../src/executors/lambda');
 
 describe('lambda executor', () => {
-    let lambdaClient, stack, task;
+    let lambdaClient, stack, task, invocationResult;
 
     beforeEach(() => {
+        invocationResult = {
+            Payload : JSON.stringify({ success : true }),
+        };
+
         lambdaClient = {
             invoke: jasmine.createSpy('lambda.invoke').and.returnValue({
-                promise: () => Promise.resolve(),
+                promise: () => Promise.resolve(invocationResult),
             }),
         };
 
@@ -23,11 +27,37 @@ describe('lambda executor', () => {
     });
 
     it('invokes the lambda with correct payload', async () => {
-        await lambdaExecutor(stack, task, lambdaClient);
+        const result = await lambdaExecutor(stack, task, lambdaClient);
 
         expect(lambdaClient.invoke).toHaveBeenCalledWith({
             FunctionName: task.config.name,
             Payload: `{"stackId":"${stack.id}","metadata":{}}`,
         });
+        expect(result).toEqual('{"success":true}');
+    });
+
+    // Documented https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-mode-exceptions.html
+    it('handles lambda invocation errors correctly', async () => {
+        invocationResult = {
+            FunctionError : 'unhandled',
+            Payload : JSON.stringify({
+                errorType: 'ReferenceError',
+                errorMessage: 'x is not defined',
+                trace : [
+                    'Trace Line 1',
+                    'Trace Line 2',
+                ]
+            })
+        }
+
+        try {
+            result = await lambdaExecutor(stack, task, lambdaClient);
+            fail("Should have thrown");
+        } catch (e) {
+            expect(e.message).toContain('ReferenceError');
+            expect(e.message).toContain('x is not defined');
+            expect(e.message).toContain('Trace Line 1');
+            expect(e.message).toContain('Trace Line 2');
+        }
     });
 });

--- a/task-satisfier/src/executors/lambda/index.js
+++ b/task-satisfier/src/executors/lambda/index.js
@@ -11,7 +11,19 @@ async function lambdaExecutor(stack, task, lambdaClient = defaultLambdaClient) {
         Payload: JSON.stringify(payload),
     };
 
-    return lambdaClient.invoke(params).promise();
+    return lambdaClient
+        .invoke(params)
+        .promise()
+        .then(data => {
+            if (data.FunctionError) {
+                const payload = JSON.parse(data.Payload);
+                const message = `${payload.errorType}: ${
+                    payload.errorMessage
+                }\n${payload.trace.join('\n')}`;
+                throw new Error(message);
+            }
+            return data.Payload;
+        });
 }
 
 module.exports = lambdaExecutor;


### PR DESCRIPTION
Lambda task execution failures weren't being caught if the lambda invocation itself failed. This fixes that.