### PR TITLE
Dockerfile version bump and non-Buildkit build fix

### DIFF
--- a/state-machine/Dockerfile
+++ b/state-machine/Dockerfile
@@ -1,15 +1,15 @@
-FROM node:8.10-alpine as base
+FROM node:12 as base
 WORKDIR /app
 
 FROM base as test
-COPY package.json yarn.lock .
+COPY package.json yarn.lock ./
 RUN yarn install
 COPY src ./src
 COPY spec ./spec
 RUN yarn test
 
 FROM base
-COPY package.json yarn.lock .
+COPY package.json yarn.lock ./
 RUN yarn install --production && yarn cache clean
 COPY --from=test /app/src ./src
 CMD ["node", "src/local.js"]

--- a/task-satisfier/Dockerfile
+++ b/task-satisfier/Dockerfile
@@ -1,15 +1,15 @@
-FROM node:8.10-alpine as base
+FROM node:12 as base
 WORKDIR /app
 
 FROM base as test
-COPY package.json yarn.lock .
+COPY package.json yarn.lock ./
 RUN apk add --no-cache ca-certificates && yarn install
 COPY src ./src
 COPY spec ./spec
 RUN yarn test
 
 FROM base
-COPY package.json yarn.lock .
+COPY package.json yarn.lock ./
 RUN yarn install --production && yarn cache clean
 COPY --from=test /app/src ./src
 CMD ["node", "src/local.js"]


### PR DESCRIPTION
Bump Dockerfiles to node:12 and fix non-Buildkit builds

Resolves #28