### PR TITLE
Allow machine config to specify args for lambda-based task

### DIFF
--- a/task-satisfier/src/executors/lambda/index.js
+++ b/task-satisfier/src/executors/lambda/index.js
@@ -9,6 +9,10 @@ async function lambdaExecutor(stack, task) {
         metadata: stack.metadata,
     };
 
+    if (task.args && typeof(task.args) === "object") {
+        payload.args = task.args
+    }
+    
     const params = {
         FunctionName: task.config.name,
         Payload: JSON.stringify(payload),

--- a/task-satisfier/src/executors/lambda/index.js
+++ b/task-satisfier/src/executors/lambda/index.js
@@ -9,8 +9,8 @@ async function lambdaExecutor(stack, task) {
         metadata: stack.metadata,
     };
 
-    if (task.args && typeof(task.args) === "object") {
-        payload.args = task.args
+    if (task.config.args && typeof(task.config.args) === "object") {
+        payload.args = task.config.args
     }
     
     const params = {


### PR DESCRIPTION
I want to be able to write a single lambda that can handle a couple of different tasks.

```yaml
  efd-setup:
    executor: lambda
    config:
      name: efd-deployment-task
      args:
         type: CreateDeployment

  efd-teardown:
    executor: lambda
    config:
      name: efd-deployment-task
      args:
         type: DestroyDeployment
```
