### PR TITLE
turn off ANSI color when running terraform

### DIFF
--- a/task-satisfier/src/executors/terraform/index.js
+++ b/task-satisfier/src/executors/terraform/index.js
@@ -102,7 +102,7 @@ async function init(workDir, stack, task) {
 
         const cmd = spawn(
             '/tmp/terraform',
-            ['init', `-backend-config="key=${key}"`, workDir],
+            ['init', '-no-color', `-backend-config="key=${key}"`, workDir],
             { shell: true, cwd: workDir },
         );
         cmd.stdout.on('data', data => log(data.toString()));
@@ -119,6 +119,7 @@ async function run(workDir, action, stackId, additionalVariables) {
         let options = [
             action,
             `-var='stack_id=${stackId}'`,
+            '-no-color',
             '-input=false',
             '-auto-approve',
         ];


### PR DESCRIPTION
The escape codes just make it harder to read the log output.