### PR TITLE
Support multiple records

### DIFF
--- a/state-machine/package.json
+++ b/state-machine/package.json
@@ -17,12 +17,12 @@
     "@cloudseam/machine-validator": "^1.1.0",
     "@middy/core": "^2.5.2",
     "@middy/sqs-partial-batch-failure": "^2.5.2",
-    "aws-sdk": "^2.384.0",
     "joi": "^14.3.0",
     "pg": "^7.7.1",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {
+    "aws-sdk": "^2.384.0",
     "concurrently": "^4.0.1",
     "jest": "24.9.0",
     "nodemon": "2.0.2",

--- a/state-machine/package.json
+++ b/state-machine/package.json
@@ -15,6 +15,8 @@
   },
   "dependencies": {
     "@cloudseam/machine-validator": "^1.1.0",
+    "@middy/core": "^2.5.2",
+    "@middy/sqs-partial-batch-failure": "^2.5.2",
     "aws-sdk": "^2.384.0",
     "joi": "^14.3.0",
     "pg": "^7.7.1",

--- a/state-machine/yarn.lock
+++ b/state-machine/yarn.lock
@@ -352,6 +352,23 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@middy/core@^2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@middy/core/-/core-2.5.2.tgz#632985cba3a3a66548cc6bb0960efd49b9e2e5d5"
+  integrity sha512-Nho5E/2e8d9GSPr6IcQXV060lgwOgI2xPocdgjSJhtdkOKjy4vpGEFP7LNU8snUjZJyjDWI01hfq1Dy06lmNNw==
+
+"@middy/sqs-partial-batch-failure@^2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@middy/sqs-partial-batch-failure/-/sqs-partial-batch-failure-2.5.2.tgz#c501ee4cc239c1ca654e1a684c378fc875cd03b5"
+  integrity sha512-Pyu313hrQLQxcoPWcAOXzwDE4/1Xhd7AoAFxOdqCcVkulZ73ibVuP3hfB7qmICquCEjuumxx1AmgEyf9xX6/+w==
+  dependencies:
+    "@middy/util" "^2.5.2"
+
+"@middy/util@^2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@middy/util/-/util-2.5.2.tgz#c4649d09687fc405fe24070ac678fff08e4f0ba9"
+  integrity sha512-dFvCbWqxpjtBCOTTguTSLCJC5FwoIC125G9f+Nl+4hAXwV2sNwZ7g0GH3T6MIvxjkHeqFYMxUm3ePjGTEYyxGg==
+
 "@types/babel__core@^7.1.0":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"


### PR DESCRIPTION
At times, it seems that multiple records are received by the state machine, even when batch sizes are set to zero. This ensures each are handled. This does evaluate each record concurrently, but in most situations, that should be ok as 1) multiple records should be rare and 2) the number of events for the same stack should be low. We can always iterate if problems arise.